### PR TITLE
14.1: Allow circle cover to have a filled circle or just an outline

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -23,6 +23,9 @@
     <color name="full_bat_bg">#01487f</color> <!-- blue-->
     <color name="low_bat_bg">#841515</color> <!-- red-->
     <color name="charge_bat_bg">#ffc107</color> <!-- yellow-->
+    <color name="outline_full_bat_bg">#0180c0</color> <!-- bright blue-->
+    <color name="outline_low_bat_bg">#c03030</color> <!-- bright red-->
+    <color name="outline_charge_bat_bg">#ffe107</color> <!-- bright yellow-->
     <color name="clock_text_color">@android:color/white</color>
 
     <color name="clock_white">#ffffff</color>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -29,12 +29,19 @@
      For example, a device with Asus Circle Cover would set 2 -->
     <integer name="config_deviceCoverType">0</integer>
 
-    <!-- Define main circle parameters (config_deviceCoverType == 1) -->
+    <!-- Define main circle parameters (config_deviceCoverType == 2) -->
+    <!-- If fill_paint is true, then the circle is filled with the
+         required colour. If fill_paint is false, then just the outline
+         of the circle is drawn, with the outline width set by
+         line_width. -->
     <integer name="x_offset" translatable="false">0</integer>
     <integer name="y_offset" translatable="false">0</integer>
     <integer name="radius_offset" translatable="false">0</integer>
+    <bool name="fill_paint" translatable="false">true</bool>
+    <integer name="line_width" translatable="false">0</integer>
 
-    <!-- Rectangular parameters (config_deviceCoverType == 2) -->
+
+    <!-- Rectangular parameters (config_deviceCoverType == 3) -->
     <integer name="rectangular_window_top" translatable="false">0</integer>
     <integer name="rectangular_window_left" translatable="false">0</integer>
     <integer name="rectangular_window_width" translatable="false">0</integer>

--- a/src/org/lineageos/flipflap/CircleBatteryView.java
+++ b/src/org/lineageos/flipflap/CircleBatteryView.java
@@ -41,6 +41,10 @@ public class CircleBatteryView extends View {
     private float mCenterX;
     private float mCenterY;
     private float mRadius;
+    private boolean mFillPaint;
+    private int mBattFullColor;
+    private int mBattLowColor;
+    private int mBattChargeColor;
 
     private boolean mBatteryStateReceiverRegistered;
     private final BroadcastReceiver mBatteryStateReceiver = new BroadcastReceiver() {
@@ -52,13 +56,13 @@ public class CircleBatteryView extends View {
                     status == BatteryManager.BATTERY_STATUS_FULL;
 
             if (!FlipFlapUtils.showBatteryStatus(mContext)) {
-                mPaint.setColor(mResources.getColor(R.color.full_bat_bg));
+                mPaint.setColor(mBattFullColor);
             } else if (isCharging) {
-                mPaint.setColor(mResources.getColor(R.color.charge_bat_bg));
+                mPaint.setColor(mBattChargeColor);
             } else if (level >= 15) {
-                mPaint.setColor(mResources.getColor(R.color.full_bat_bg));
+                mPaint.setColor(mBattFullColor);
             } else {
-                mPaint.setColor(mResources.getColor(R.color.low_bat_bg));
+                mPaint.setColor(mBattLowColor);
             }
             postInvalidate();
         }
@@ -76,11 +80,23 @@ public class CircleBatteryView extends View {
         super(context, attrs, defStyleAttr);
 
         mContext = context;
-
+        mResources = mContext.getResources();
         mPaint = new Paint();
         mPaint.setAntiAlias(true);
-        mPaint.setStyle(Style.FILL);
-        mResources = mContext.getResources();
+
+        mFillPaint = mResources.getBoolean(R.bool.fill_paint);
+        if (mFillPaint) {
+            mPaint.setStyle(Style.FILL);
+            mBattFullColor = mResources.getColor(R.color.full_bat_bg);
+            mBattLowColor = mResources.getColor(R.color.low_bat_bg);
+            mBattChargeColor = mResources.getColor(R.color.charge_bat_bg);
+        } else {
+            mPaint.setStyle(Style.STROKE);
+            mPaint.setStrokeWidth(mResources.getInteger(R.integer.line_width));
+            mBattFullColor = mResources.getColor(R.color.outline_full_bat_bg);
+            mBattLowColor = mResources.getColor(R.color.outline_low_bat_bg);
+            mBattChargeColor = mResources.getColor(R.color.outline_charge_bat_bg);
+        }
     }
 
     @Override


### PR DESCRIPTION
Default is the same as it has been until now. The outline option is for the ZUK Z2 where the official case has a clear plastic ring around the circular cutout, and having a matching ring of colour on the LCD makes it look like the plastic ring is glowing. Quite a nice effect.